### PR TITLE
feat: 채팅 조회 시 SSE 통신 분리#11

### DIFF
--- a/src/main/java/ScreeningHumanity/stockChatServer/adapter/in/web/controller/StockChatController.java
+++ b/src/main/java/ScreeningHumanity/stockChatServer/adapter/in/web/controller/StockChatController.java
@@ -8,6 +8,7 @@ import ScreeningHumanity.stockChatServer.application.port.in.dto.StockChatInDto;
 import ScreeningHumanity.stockChatServer.application.port.in.usecase.StockChatUseCase;
 import ScreeningHumanity.stockChatServer.global.common.token.DecodingToken;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,14 +40,19 @@ public class StockChatController {
 				stockChatUseCase.sendChat(StockChatInDto.getStockChatVo(vo, uuid)));
 	}
 
-	@GetMapping(value = "/chat/{stockCode}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	@GetMapping(value = "/reactive-chat/{stockCode}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public Flux<StockChatOutVo> getReactiveChats(
+			@PathVariable String stockCode) {
+		return StockChatOutVo.getStockChatInDto(stockChatUseCase.getReactiveChats(stockCode));
+	}
+
+	@GetMapping(value = "/chat/{stockCode}/{pageSize}")
 	public Flux<StockChatOutVo> getChatsPagination(
-			@PathVariable String stockCode,
+			@PathVariable("stockCode") String stockCode,
+			@PathVariable("pageSize") @Min(value = 1) Integer pageSize,
 			@RequestParam(required = false) String lastId
 	) {
 		return StockChatOutVo.getStockChatInDto(
-				stockChatUseCase.getChatsPagination(stockCode, 5, lastId));
+				stockChatUseCase.getChatsPagination(stockCode, pageSize, lastId));
 	}
 }
-
-

--- a/src/main/java/ScreeningHumanity/stockChatServer/adapter/out/infrastructure/mongo/persistance/StockChatAdapter.java
+++ b/src/main/java/ScreeningHumanity/stockChatServer/adapter/out/infrastructure/mongo/persistance/StockChatAdapter.java
@@ -29,8 +29,7 @@ public class StockChatAdapter implements LoadStockChatPort, SaveStockChatPort {
 					stockChatRepository.findByStockCodeAndIdLessThan(stockCode, pageable));
 		} else {
 			return StockChatOutDto.getStockChatEntityFlux(
-					stockChatRepository.findByStockCodeAndIdLessThan(stockCode,
-							new ObjectId(lastId), pageable));
+					stockChatRepository.findByStockCodeAndIdLessThan(stockCode, pageable, new ObjectId(lastId)));
 		}
 	}
 

--- a/src/main/java/ScreeningHumanity/stockChatServer/adapter/out/infrastructure/mongo/repository/StockChatRepository.java
+++ b/src/main/java/ScreeningHumanity/stockChatServer/adapter/out/infrastructure/mongo/repository/StockChatRepository.java
@@ -1,22 +1,24 @@
 package ScreeningHumanity.stockChatServer.adapter.out.infrastructure.mongo.repository;
 
 import ScreeningHumanity.stockChatServer.adapter.out.infrastructure.mongo.entity.StockChatEntity;
-
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import org.springframework.data.repository.query.Param;
 import reactor.core.publisher.Flux;
 
-public interface StockChatRepository extends ReactiveMongoRepository<StockChatEntity, String>, CustomStockChatRepository{
-	@Query(value = "{ 'stockCode': ?0, '_id': { '$lt': ?1 } }", sort = "{createAt: -1}")
-	Flux<StockChatEntity> findByStockCodeAndIdLessThan(
-			String stockCode,
-			ObjectId id,
-			Pageable pageable);
+public interface StockChatRepository extends ReactiveMongoRepository<StockChatEntity, String>,
+		CustomStockChatRepository {
 
-	@Query(value = "{ 'stockCode': ?0 }", sort = "{createAt: -1}")
+	@Query(value = "{ 'stockCode': :#{#stockCode}, '_id': { '$lt': :#{#id} } }", sort = "{createAt: -1}")
 	Flux<StockChatEntity> findByStockCodeAndIdLessThan(
-			String stockCode,
+			@Param("stockCode") String stockCode,
+			Pageable pageable,
+			@Param("id") ObjectId id);
+
+	@Query(value = "{ 'stockCode': :#{#stockCode} }", sort = "{createAt: -1}")
+	Flux<StockChatEntity> findByStockCodeAndIdLessThan(
+			@Param("stockCode") String stockCode,
 			Pageable pageable);
 }

--- a/src/main/java/ScreeningHumanity/stockChatServer/application/port/in/usecase/StockChatUseCase.java
+++ b/src/main/java/ScreeningHumanity/stockChatServer/application/port/in/usecase/StockChatUseCase.java
@@ -8,6 +8,8 @@ import reactor.core.publisher.Mono;
 public interface StockChatUseCase {
 	Mono<StockChatInDto> sendChat(StockChatInDto dto);
 
+	Flux<StockChatInDto> getReactiveChats(String stockCode);
+
 	Flux<StockChatInDto> getChatsPagination(String stockCode, int pageSize, String lastId);
 
 	void changeNickName(ChangeNickNameInDto dto);

--- a/src/main/java/ScreeningHumanity/stockChatServer/application/service/StockChatService.java
+++ b/src/main/java/ScreeningHumanity/stockChatServer/application/service/StockChatService.java
@@ -39,11 +39,15 @@ public class StockChatService implements StockChatUseCase {
 	}
 
 	@Override
+	public Flux<StockChatInDto> getReactiveChats(String stockCode) {
+		return stockChatSink.asFlux()
+				.filter(stockChat -> stockChat.getStockCode().equals(stockCode));
+	}
+
+	@Override
 	public Flux<StockChatInDto> getChatsPagination(String stockCode, int pageSize, String lastId) {
 		return StockChatInDto.getStockChats(
-						StockChat.getStockChats(loadStockChatPort.getChatsPagination(stockCode, pageSize, lastId)))
-				.concatWith(stockChatSink.asFlux()
-						.filter(stockChat -> stockChat.getStockCode().equals(stockCode)));
+				StockChat.getStockChats(loadStockChatPort.getChatsPagination(stockCode, pageSize, lastId)));
 	}
 
 	@Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,9 @@ eureka:
     service-url:
       defaultZone: ${EUREKA_URl}
 
+kafka:
+  bootstrap-server: ${KAFKA_SERVER}
+
 springdoc:
   packages-to-scan: ScreeningHumanity.stockChatServer
   default-consumes-media-type: application/json;charset=UTF-8


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) feat : pull request template#17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 패키징 구조 변경
- [ ] 파일명 변경
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [ ] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용

<!--@{Issue번호} + Enter
ex) @17
이슈와 PR 연결을 위해 사용합니다!-->
#11 
- 채팅 조회 시 SSE 와 그 전 채팅 데이터를 다른 API로 조회 
  - 실시간으로 들어오는 채팅은 SSE 로 조회
  - 나머지 존재하던 채팅은 일반 GET으로 조회 
